### PR TITLE
Use date time offset and add product to /prices endpoint

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,1 +1,0 @@
-extends: ["spectral:oas"]

--- a/samples/tariffs-response.json
+++ b/samples/tariffs-response.json
@@ -540,7 +540,7 @@
             },
             "price": null,
             "unit": "kW",
-            "url": "/prices/e33307b6-77b2-4d7d-b33f-908d2cc9ebbb",
+            "url": "/prices?product=ProductCode3",
             "peakIdentificationSettings": null,
             "recurringPeriods": null
           }

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -27,17 +27,11 @@ if git diff --cached --name-only | grep -q "specification/"; then
 fi
 
 mkdir -p build
-npx @redocly/cli@latest bundle specification/gridtariffapi.json -o build/openapi.json
+npx @redocly/cli@2.28.0 bundle specification/gridtariffapi.json -o build/openapi.json
 
-npx @redocly/cli@latest lint build/openapi.json
+npx @redocly/cli@2.28.0 lint build/openapi.json
 if [ $? -ne 0 ]; then
   echo "❌ ERROR: OpenAPI validation failed. Please fix the issues before committing."
-  exit 1
-fi
-
-npx @stoplight/spectral-cli@latest lint build/openapi.json --ruleset .spectral.yaml
-if [ $? -ne 0 ]; then
-  echo "❌ ERROR: Spectral lint failed. Please fix the issues before committing."
   exit 1
 fi
 
@@ -46,12 +40,6 @@ fi
 #   echo "❌ ERROR: OpenAPI validation failed. Please fix the issues before committing."
 #   exit 1
 # fi
-
-npx @stoplight/spectral-cli lint $catalogue_api_index_file --ruleset .spectral.yaml
-if [ $? -ne 0 ]; then
-  echo "❌ ERROR: Spectral lint failed. Please fix the issues before committing."
-  exit 1
-fi
 
 dotnet build src/ControllerGenerator
 dotnet build src/SwaggerUI

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -27,15 +27,15 @@ if git diff --cached --name-only | grep -q "specification/"; then
 fi
 
 mkdir -p build
-npx @redocly/cli bundle specification/gridtariffapi.json -o build/openapi.json
+npx @redocly/cli@latest bundle specification/gridtariffapi.json -o build/openapi.json
 
-npx @redocly/cli lint build/openapi.json
+npx @redocly/cli@latest lint build/openapi.json
 if [ $? -ne 0 ]; then
   echo "❌ ERROR: OpenAPI validation failed. Please fix the issues before committing."
   exit 1
 fi
 
-npx @stoplight/spectral-cli lint build/openapi.json --ruleset .spectral.yaml
+npx @stoplight/spectral-cli@latest lint build/openapi.json --ruleset .spectral.yaml
 if [ $? -ne 0 ]; then
   echo "❌ ERROR: Spectral lint failed. Please fix the issues before committing."
   exit 1

--- a/specification/common.schema.json
+++ b/specification/common.schema.json
@@ -20,12 +20,6 @@
       "example": "Fixed price for a contract with a fuse size of 25 A.",
       "additionalProperties": false
     },
-    "Url": {
-      "type": "string",
-      "description": "A URL string.",
-      "example": "/prices/216783ff-5dda-4c38-b491-d6f0fcee9a9b",
-      "additionalProperties": false
-    },
     "MeteringPointId": {
       "type": "string",
       "description": "Identifier for a physical metering point (MPID)",

--- a/specification/gridtariffapi.json
+++ b/specification/gridtariffapi.json
@@ -178,15 +178,27 @@
         }
       }
     },
-    "/prices/{componentId}": {
+    "/prices": {
       "parameters": [
         {
           "name": "componentId",
           "description": "A price component id.",
-          "in": "path",
-          "required": true,
+          "in": "query",
+          "required": false,
           "schema": {
             "$ref": "common.schema.json#/definitions/Uuid"
+          }
+        },
+        {
+          "name": "product",
+          "description": "The product defined in the parent tariff object of the power price component.",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "description": "The tariff product.",
+            "example": "HOUR_63A_HOUSE",
+            "additionalProperties": false
           }
         },
         {

--- a/specification/gridtariffapi.json
+++ b/specification/gridtariffapi.json
@@ -204,7 +204,7 @@
           "in": "query",
           "required": false,
           "schema": {
-            "$ref": "time.schema.json#/definitions/DateTime"
+            "$ref": "time.schema.json#/definitions/DateTimeOffset"
           }
         },
         {
@@ -213,7 +213,7 @@
           "in": "query",
           "required": false,
           "schema": {
-            "$ref": "time.schema.json#/definitions/DateTime"
+            "$ref": "time.schema.json#/definitions/DateTimeOffset"
           }
         }
       ],
@@ -279,9 +279,6 @@
             "description": "Version of the implementation. The format is set by the operator and can differ. In this example -r4 is the revision number of the implementation and the first three numbers the API version.",
             "example": "1.2.3-r4"
           },
-          "lastUpdated": {
-            "$ref": "time.schema.json#/definitions/DateTime"
-          },
           "operator": {
             "type": "string",
             "description": "Name of the company or organization operating this server.",
@@ -299,7 +296,7 @@
         "required": [
           "name",
           "apiVersion",
-          "lastUpdated",
+          "implementationVersion",
           "operator",
           "timeZone"
         ],

--- a/specification/power.schema.json
+++ b/specification/power.schema.json
@@ -36,7 +36,10 @@
           "$ref": "common.schema.json#/definitions/Unit"
         },
         "url": {
-          "$ref": "common.schema.json#/definitions/Url"
+          "type": "string",
+          "description": "URL string that is either a root relative or absolute path to the prices endpoint. It must follow the /prices path defined in this specification.",
+          "example": "/prices?product=HOUR_63A_HOUSE",
+          "additionalProperties": false
         },
         "peakIdentificationSettings": {
           "$ref": "power.schema.json#/definitions/PeakIdentificationSettings"

--- a/specification/price.schema.json
+++ b/specification/price.schema.json
@@ -68,13 +68,13 @@
       "type": "object",
       "properties": {
         "created": {
-          "$ref": "time.schema.json#/definitions/DateTime"
+          "$ref": "time.schema.json#/definitions/DateTimeOffset"
         },
         "start": {
-          "$ref": "time.schema.json#/definitions/DateTime"
+          "$ref": "time.schema.json#/definitions/DateTimeOffset"
         },
         "end": {
-          "$ref": "time.schema.json#/definitions/DateTime"
+          "$ref": "time.schema.json#/definitions/DateTimeOffset"
         },
         "priceExVat": {
           "type": "number",

--- a/specification/price.schema.json
+++ b/specification/price.schema.json
@@ -30,17 +30,8 @@
       "description": "Time differentiated prices for a price component.",
       "type": "object",
       "properties": {
-        "componentId": {
-          "$ref": "common.schema.json#/definitions/Uuid"
-        },
-        "timeZone": {
-          "$ref": "time.schema.json#/definitions/TimeZone"
-        },
         "currency": {
           "$ref": "price.schema.json#/definitions/Currency"
-        },
-        "resolution": {
-          "$ref": "time.schema.json#/definitions/Duration"
         },
         "actual": {
           "type": "array",
@@ -48,7 +39,7 @@
             "$ref": "price.schema.json#/definitions/PriceListEntry"
           }
         },
-        "forecast": {
+        "preview": {
           "type": "array",
           "items": {
             "$ref": "price.schema.json#/definitions/PriceListEntry"
@@ -56,12 +47,10 @@
         }
       },
       "required": [
-        "componentId",
         "currency",
-        "resolution",
         "actual"
       ],
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "PriceListEntry": {
       "description": "A timed price entry that belongs to a price list.",
@@ -88,7 +77,6 @@
         }
       },
       "required": [
-        "created",
         "start",
         "end",
         "priceExVat",

--- a/specification/tariff.schema.json
+++ b/specification/tariff.schema.json
@@ -16,14 +16,14 @@
           "description": "Detailed description of the grid tariff.",
           "type": "string"
         },
+        "published": {
+          "$ref": "time.schema.json#/definitions/DateTimeOffset"
+        },
         "validPeriod": {
           "$ref": "time.schema.json#/definitions/DateInterval"
         },
         "timeZone": {
           "$ref": "time.schema.json#/definitions/TimeZone"
-        },
-        "lastUpdated": {
-          "$ref": "time.schema.json#/definitions/DateTime"
         },
         "companyName": {
           "description": "Name of the grid company.",
@@ -60,9 +60,9 @@
       "required": [
         "id",
         "name",
+        "published",
         "validPeriod",
         "timeZone",
-        "lastUpdated",
         "companyName",
         "companyOrgNo",
         "product",

--- a/specification/time.schema.json
+++ b/specification/time.schema.json
@@ -30,12 +30,12 @@
       "example": "2025-05-25",
       "description": "Date in ISO 8601 format."
     },
-    "DateTime": {
+    "DateTimeOffset": {
       "type": "string",
       "format": "date-time",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
-      "example": "2025-05-25T01:00:00",
-      "description": "Date-time in ISO 8601 format without offset."
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+      "example": "2025-05-25T01:00:00+01:00",
+      "description": "Date-time in ISO 8601 / RFC 3339 style with required numeric offset in the form ±HH:MM."
     },
     "Time": {
       "type": "string",

--- a/src/ControllerGenerator/Generated/GeneratedControllerBase.cs
+++ b/src/ControllerGenerator/Generated/GeneratedControllerBase.cs
@@ -80,7 +80,7 @@ namespace GeneratedController
         /// <param name="toExcluding">Get all defined prices up to this time. Default is fromIncluding + 7 days.</param>
         /// <returns>The prices for the provided component id and time period.</returns>
         [Microsoft.AspNetCore.Mvc.HttpGet, Microsoft.AspNetCore.Mvc.Route("prices/{componentId}", Name = "GetPrices")]
-        public abstract System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult<PricesResponse>> GetPrices([Microsoft.AspNetCore.Mvc.ModelBinding.BindRequired] System.Guid componentId, [Microsoft.AspNetCore.Mvc.FromQuery] System.DateOnly? date, [Microsoft.AspNetCore.Mvc.FromQuery] System.DateTime? fromIncluding, [Microsoft.AspNetCore.Mvc.FromQuery] System.DateTime? toExcluding);
+        public abstract System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult<PricesResponse>> GetPrices([Microsoft.AspNetCore.Mvc.ModelBinding.BindRequired] System.Guid componentId, [Microsoft.AspNetCore.Mvc.FromQuery] System.DateOnly? date, [Microsoft.AspNetCore.Mvc.FromQuery] System.DateTimeOffset? fromIncluding, [Microsoft.AspNetCore.Mvc.FromQuery] System.DateTimeOffset? toExcluding);
 
     }
 
@@ -104,13 +104,9 @@ namespace GeneratedController
         /// <summary>
         /// Version of the implementation. The format is set by the operator and can differ. In this example -r4 is the revision number of the implementation and the first three numbers the API version.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("implementationVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string ImplementationVersion { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("lastUpdated", Required = Newtonsoft.Json.Required.Always)]
+        [Newtonsoft.Json.JsonProperty("implementationVersion", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$")]
-        public System.DateTime LastUpdated { get; set; }
+        public string ImplementationVersion { get; set; }
 
         /// <summary>
         /// Name of the company or organization operating this server.
@@ -618,6 +614,11 @@ namespace GeneratedController
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Description { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("published", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$")]
+        public System.DateTimeOffset Published { get; set; }
+
         [Newtonsoft.Json.JsonProperty("validPeriod", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
         public DateInterval ValidPeriod { get; set; } = new DateInterval();
@@ -625,11 +626,6 @@ namespace GeneratedController
         [Newtonsoft.Json.JsonProperty("timeZone", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string TimeZone { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("lastUpdated", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$")]
-        public System.DateTime LastUpdated { get; set; }
 
         /// <summary>
         /// Name of the grid company.
@@ -721,18 +717,18 @@ namespace GeneratedController
     {
         [Newtonsoft.Json.JsonProperty("created", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$")]
-        public System.DateTime Created { get; set; }
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$")]
+        public System.DateTimeOffset Created { get; set; }
 
         [Newtonsoft.Json.JsonProperty("start", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$")]
-        public System.DateTime Start { get; set; }
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$")]
+        public System.DateTimeOffset Start { get; set; }
 
         [Newtonsoft.Json.JsonProperty("end", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$")]
-        public System.DateTime End { get; set; }
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$")]
+        public System.DateTimeOffset End { get; set; }
 
         [Newtonsoft.Json.JsonProperty("priceExVat", Required = Newtonsoft.Json.Required.Always)]
         public decimal PriceExVat { get; set; }

--- a/src/ControllerGenerator/Generated/GeneratedControllerBase.cs
+++ b/src/ControllerGenerator/Generated/GeneratedControllerBase.cs
@@ -75,12 +75,13 @@ namespace GeneratedController
         /// Returns prices for a price component for a given time period. The time period defaults to fromIncluding = today 00:00 and toExcluding = today 00:00 plus 7 full days. By looking 7 days ahead, forecasted prices are also returned.
         /// </remarks>
         /// <param name="componentId">A price component id.</param>
+        /// <param name="product">The product defined in the parent tariff object of the power price component.</param>
         /// <param name="date">Get all defined prices for the given date.</param>
         /// <param name="fromIncluding">Get all defined prices from this time and forward. Default is today midnight.</param>
         /// <param name="toExcluding">Get all defined prices up to this time. Default is fromIncluding + 7 days.</param>
         /// <returns>The prices for the provided component id and time period.</returns>
-        [Microsoft.AspNetCore.Mvc.HttpGet, Microsoft.AspNetCore.Mvc.Route("prices/{componentId}", Name = "GetPrices")]
-        public abstract System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult<PricesResponse>> GetPrices([Microsoft.AspNetCore.Mvc.ModelBinding.BindRequired] System.Guid componentId, [Microsoft.AspNetCore.Mvc.FromQuery] System.DateOnly? date, [Microsoft.AspNetCore.Mvc.FromQuery] System.DateTimeOffset? fromIncluding, [Microsoft.AspNetCore.Mvc.FromQuery] System.DateTimeOffset? toExcluding);
+        [Microsoft.AspNetCore.Mvc.HttpGet, Microsoft.AspNetCore.Mvc.Route("prices", Name = "GetPrices")]
+        public abstract System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult<PricesResponse>> GetPrices([Microsoft.AspNetCore.Mvc.FromQuery] System.Guid? componentId, [Microsoft.AspNetCore.Mvc.FromQuery] string product, [Microsoft.AspNetCore.Mvc.FromQuery] System.DateOnly? date, [Microsoft.AspNetCore.Mvc.FromQuery] System.DateTimeOffset? fromIncluding, [Microsoft.AspNetCore.Mvc.FromQuery] System.DateTimeOffset? toExcluding);
 
     }
 
@@ -553,6 +554,9 @@ namespace GeneratedController
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string Unit { get; set; }
 
+        /// <summary>
+        /// URL string that is either a root relative or absolute path to the prices endpoint. It must follow the /prices path defined in this specification.
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("url", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Url { get; set; }
 
@@ -715,8 +719,7 @@ namespace GeneratedController
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.2.0.0 (NJsonSchema v11.1.0.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class PriceListEntry
     {
-        [Newtonsoft.Json.JsonProperty("created", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [Newtonsoft.Json.JsonProperty("created", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$")]
         public System.DateTimeOffset Created { get; set; }
 
@@ -744,27 +747,25 @@ namespace GeneratedController
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.2.0.0 (NJsonSchema v11.1.0.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class PricesResponse
     {
-        [Newtonsoft.Json.JsonProperty("componentId", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public System.Guid ComponentId { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("timeZone", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string TimeZone { get; set; }
-
         [Newtonsoft.Json.JsonProperty("currency", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string Currency { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("resolution", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public System.String Resolution { get; set; }
 
         [Newtonsoft.Json.JsonProperty("actual", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.List<PriceListEntry> Actual { get; set; } = new System.Collections.Generic.List<PriceListEntry>();
 
-        [Newtonsoft.Json.JsonProperty("forecast", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.List<PriceListEntry> Forecast { get; set; }
+        [Newtonsoft.Json.JsonProperty("preview", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.List<PriceListEntry> Preview { get; set; }
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 

--- a/src/ControllerGenerator/Generated/gridtariffapi-bundle.json
+++ b/src/ControllerGenerator/Generated/gridtariffapi-bundle.json
@@ -204,7 +204,7 @@
           "in": "query",
           "required": false,
           "schema": {
-            "$ref": "#/components/schemas/DateTime"
+            "$ref": "#/components/schemas/DateTimeOffset"
           }
         },
         {
@@ -213,7 +213,7 @@
           "in": "query",
           "required": false,
           "schema": {
-            "$ref": "#/components/schemas/DateTime"
+            "$ref": "#/components/schemas/DateTimeOffset"
           }
         }
       ],
@@ -279,9 +279,6 @@
             "description": "Version of the implementation. The format is set by the operator and can differ. In this example -r4 is the revision number of the implementation and the first three numbers the API version.",
             "example": "1.2.3-r4"
           },
-          "lastUpdated": {
-            "$ref": "#/components/schemas/DateTime"
-          },
           "operator": {
             "type": "string",
             "description": "Name of the company or organization operating this server.",
@@ -299,7 +296,7 @@
         "required": [
           "name",
           "apiVersion",
-          "lastUpdated",
+          "implementationVersion",
           "operator",
           "timeZone"
         ],
@@ -407,13 +404,6 @@
         ],
         "additionalProperties": true
       },
-      "DateTime": {
-        "type": "string",
-        "format": "date-time",
-        "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
-        "example": "2025-05-25T01:00:00",
-        "description": "Date-time in ISO 8601 format without offset."
-      },
       "TimeZone": {
         "type": "string",
         "description": "Time zone as described in the IANA Time Zone Database (https://www.iana.org/time-zones) e.g., 'Europe/Stockholm'.",
@@ -425,6 +415,13 @@
         "description": "Globally unique identifier",
         "example": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
         "additionalProperties": false
+      },
+      "DateTimeOffset": {
+        "type": "string",
+        "format": "date-time",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+        "example": "2025-05-25T01:00:00+01:00",
+        "description": "Date-time in ISO 8601 / RFC 3339 style with required numeric offset in the form ±HH:MM."
       },
       "Date": {
         "type": "string",
@@ -917,14 +914,14 @@
             "description": "Detailed description of the grid tariff.",
             "type": "string"
           },
+          "published": {
+            "$ref": "#/components/schemas/DateTimeOffset"
+          },
           "validPeriod": {
             "$ref": "#/components/schemas/DateInterval"
           },
           "timeZone": {
             "$ref": "#/components/schemas/TimeZone"
-          },
-          "lastUpdated": {
-            "$ref": "#/components/schemas/DateTime"
           },
           "companyName": {
             "description": "Name of the grid company.",
@@ -961,9 +958,9 @@
         "required": [
           "id",
           "name",
+          "published",
           "validPeriod",
           "timeZone",
-          "lastUpdated",
           "companyName",
           "companyOrgNo",
           "product",
@@ -1034,13 +1031,13 @@
         "type": "object",
         "properties": {
           "created": {
-            "$ref": "#/components/schemas/DateTime"
+            "$ref": "#/components/schemas/DateTimeOffset"
           },
           "start": {
-            "$ref": "#/components/schemas/DateTime"
+            "$ref": "#/components/schemas/DateTimeOffset"
           },
           "end": {
-            "$ref": "#/components/schemas/DateTime"
+            "$ref": "#/components/schemas/DateTimeOffset"
           },
           "priceExVat": {
             "type": "number",

--- a/src/ControllerGenerator/Generated/gridtariffapi-bundle.json
+++ b/src/ControllerGenerator/Generated/gridtariffapi-bundle.json
@@ -178,15 +178,27 @@
         }
       }
     },
-    "/prices/{componentId}": {
+    "/prices": {
       "parameters": [
         {
           "name": "componentId",
           "description": "A price component id.",
-          "in": "path",
-          "required": true,
+          "in": "query",
+          "required": false,
           "schema": {
             "$ref": "#/components/schemas/Uuid"
+          }
+        },
+        {
+          "name": "product",
+          "description": "The product defined in the parent tariff object of the power price component.",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "description": "The tariff product.",
+            "example": "HOUR_63A_HOUSE",
+            "additionalProperties": false
           }
         },
         {
@@ -771,12 +783,6 @@
         ],
         "additionalProperties": false
       },
-      "Url": {
-        "type": "string",
-        "description": "A URL string.",
-        "example": "/prices/216783ff-5dda-4c38-b491-d6f0fcee9a9b",
-        "additionalProperties": false
-      },
       "PeakFunction": {
         "description": "A pseudo code function that describes how to identify a power peak for one power price component. Usage examples at https://someexamples.",
         "type": "string",
@@ -846,7 +852,10 @@
             "$ref": "#/components/schemas/Unit"
           },
           "url": {
-            "$ref": "#/components/schemas/Url"
+            "type": "string",
+            "description": "URL string that is either a root relative or absolute path to the prices endpoint. It must follow the /prices path defined in this specification.",
+            "example": "/prices?product=HOUR_63A_HOUSE",
+            "additionalProperties": false
           },
           "peakIdentificationSettings": {
             "$ref": "#/components/schemas/PeakIdentificationSettings"
@@ -1051,7 +1060,6 @@
           }
         },
         "required": [
-          "created",
           "start",
           "end",
           "priceExVat",
@@ -1063,17 +1071,8 @@
         "description": "Time differentiated prices for a price component.",
         "type": "object",
         "properties": {
-          "componentId": {
-            "$ref": "#/components/schemas/Uuid"
-          },
-          "timeZone": {
-            "$ref": "#/components/schemas/TimeZone"
-          },
           "currency": {
             "$ref": "#/components/schemas/Currency"
-          },
-          "resolution": {
-            "$ref": "#/components/schemas/Duration"
           },
           "actual": {
             "type": "array",
@@ -1081,7 +1080,7 @@
               "$ref": "#/components/schemas/PriceListEntry"
             }
           },
-          "forecast": {
+          "preview": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PriceListEntry"
@@ -1089,12 +1088,10 @@
           }
         },
         "required": [
-          "componentId",
           "currency",
-          "resolution",
           "actual"
         ],
-        "additionalProperties": false
+        "additionalProperties": true
       }
     },
     "responses": {

--- a/src/ControllerGenerator/config.nswag
+++ b/src/ControllerGenerator/config.nswag
@@ -37,7 +37,7 @@
       "jsonConverters": null,
       "anyType": "object",
       "dateType": "System.DateOnly",
-      "dateTimeType": "System.DateTime",
+      "dateTimeType": "System.DateTimeOffset",
       "timeType": "System.TimeOnly",
       "timeSpanType": "System.String",
       "arrayType": "System.Collections.Generic.List",

--- a/src/ExampleController/Data/tariffs.json
+++ b/src/ExampleController/Data/tariffs.json
@@ -230,7 +230,7 @@
                 "costFunction": "sum(peak(c)*price(c))",
                 "components": [
                     {
-                        "id": "e33307b6-77b2-4d7d-b33f-908d2cc9ebbb",
+                        "id": "dfe1618d-a6b7-4406-a7be-eacbf0a6ad6a",
                         "name": "Power peak fee",
                         "description": "Power fee for the monthly maximum power usage.",
                         "type": "peak",
@@ -379,7 +379,7 @@
                             "fromIncluding": "2025-01-01",
                             "toExcluding": "2026-01-01"
                         },
-                        "url": "/prices/e33307b6-77b2-4d7d-b33f-908d2cc9ebbb"
+                        "url": "/prices?product=ProductCode3"
                     }
                 ]
             }

--- a/src/ExampleController/GridTariffController.cs
+++ b/src/ExampleController/GridTariffController.cs
@@ -33,7 +33,6 @@ public class GridTariffController(IWebHostEnvironment hostEnvironment) : Generat
             Operator = "The Grid Company AB",
             TimeZone = "Europe/Stockholm",
             IdentityProviderUrl = "https://idp.gridcompany.se/oath2/token",
-            LastUpdated = DateTime.Parse("2025-11-28"),
             AdditionalProperties = additionalProperties
         };
 
@@ -44,8 +43,8 @@ public class GridTariffController(IWebHostEnvironment hostEnvironment) : Generat
     public override async Task<ActionResult<PricesResponse>> GetPrices(
         [BindRequired] Guid componentId,
         [FromQuery] DateOnly? date,
-        [FromQuery] DateTime? fromIncluding,
-        [FromQuery] DateTime? toExcluding)
+        [FromQuery] DateTimeOffset? fromIncluding,
+        [FromQuery] DateTimeOffset? toExcluding)
     {
         if (!componentId.Equals(Guid.Parse("e33307b6-77b2-4d7d-b33f-908d2cc9ebbb")))
         {
@@ -54,8 +53,8 @@ public class GridTariffController(IWebHostEnvironment hostEnvironment) : Generat
 
         DateTime now = DateTime.Now;
         DateTime today = now.Date;
-        DateTime from = fromIncluding ?? today;
-        DateTime to = toExcluding ?? from.AddDays(7);
+        DateTimeOffset from = fromIncluding ?? today;
+        DateTimeOffset to = toExcluding ?? from.AddDays(7);
         if (date is DateOnly d)
         {
             from = d.ToDateTime(TimeOnly.MinValue);
@@ -70,7 +69,7 @@ public class GridTariffController(IWebHostEnvironment hostEnvironment) : Generat
         List<PriceListEntry> forecast = [];
         for (int i = 0; i < numberOfHours; i++)
         {
-            DateTime start = from.AddHours(i);
+            DateTimeOffset start = from.AddHours(i);
             PriceListEntry price = new()
             {
                 Created = from.Date.AddHours(-12),

--- a/src/ExampleController/GridTariffController.cs
+++ b/src/ExampleController/GridTariffController.cs
@@ -41,12 +41,24 @@ public class GridTariffController(IWebHostEnvironment hostEnvironment) : Generat
     }
 
     public override async Task<ActionResult<PricesResponse>> GetPrices(
-        [BindRequired] Guid componentId,
+        [FromQuery] Guid? componentId,
+        [FromQuery] string? product,
         [FromQuery] DateOnly? date,
         [FromQuery] DateTimeOffset? fromIncluding,
         [FromQuery] DateTimeOffset? toExcluding)
     {
-        if (!componentId.Equals(Guid.Parse("e33307b6-77b2-4d7d-b33f-908d2cc9ebbb")))
+        if (componentId == null || componentId == Guid.Empty)
+        {
+            if (product == null || product == string.Empty)
+            {
+                return BadRequest("Must specify either componentId or product.");
+            }
+            else if (!product.Equals("ProductCode3"))
+            {
+                return NotFound($"Found no price list with id {componentId}");
+            }
+        }
+        else if (!componentId.Equals(Guid.Parse("e33307b6-77b2-4d7d-b33f-908d2cc9ebbb")))
         {
             return NotFound($"Found no price list with id {componentId}");
         }
@@ -66,7 +78,7 @@ public class GridTariffController(IWebHostEnvironment hostEnvironment) : Generat
         DateTime tomorrow = today.AddDays(1);
 
         List<PriceListEntry> actual = [];
-        List<PriceListEntry> forecast = [];
+        List<PriceListEntry> preview = [];
         for (int i = 0; i < numberOfHours; i++)
         {
             DateTimeOffset start = from.AddHours(i);
@@ -85,18 +97,15 @@ public class GridTariffController(IWebHostEnvironment hostEnvironment) : Generat
             }
             else
             {
-                forecast.Add(price);
+                preview.Add(price);
             }
         }
 
         PricesResponse response = new()
         {
-            ComponentId = componentId,
-            TimeZone = "Europe/Stockholm",
             Currency = "SEK",
-            Resolution = "PT1H",
             Actual = actual,
-            Forecast = forecast
+            Preview = preview
         };
 
         await Task.CompletedTask;


### PR DESCRIPTION
- Use DateTimeOffset instead of DateTime to enforce explicit offset on both responses and requests
- Add product as a query parameter for the /prices endpoint

Fixes #63 