### PR TITLE
Add tariffDataLastUpdated to InfoResponse

### DIFF
--- a/specification/gridtariffapi.json
+++ b/specification/gridtariffapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Grid Tariff API",
     "description": "Provides grid tariffs from Swedish DSOs.",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "contact": {
       "name": "Grid Tariff API",
       "url": "https://github.com/RI-SE/Eltariff-API"
@@ -291,6 +291,9 @@
             "description": "Version of the implementation. The format is set by the operator and can differ. In this example -r4 is the revision number of the implementation and the first three numbers the API version.",
             "example": "1.2.3-r4"
           },
+          "tariffDataLastUpdated": {
+            "$ref": "time.schema.json#/definitions/DateTimeWithOffset"
+          },
           "operator": {
             "type": "string",
             "description": "Name of the company or organization operating this server.",
@@ -309,6 +312,7 @@
           "name",
           "apiVersion",
           "implementationVersion",
+          "tariffDataLastUpdated",
           "operator",
           "timeZone"
         ],

--- a/specification/gridtariffapi.json
+++ b/specification/gridtariffapi.json
@@ -216,7 +216,7 @@
           "in": "query",
           "required": false,
           "schema": {
-            "$ref": "time.schema.json#/definitions/DateTimeOffset"
+            "$ref": "time.schema.json#/definitions/DateTimeWithOffset"
           }
         },
         {
@@ -225,7 +225,7 @@
           "in": "query",
           "required": false,
           "schema": {
-            "$ref": "time.schema.json#/definitions/DateTimeOffset"
+            "$ref": "time.schema.json#/definitions/DateTimeWithOffset"
           }
         }
       ],

--- a/specification/gridtariffapi.json
+++ b/specification/gridtariffapi.json
@@ -292,7 +292,10 @@
             "example": "1.2.3-r4"
           },
           "tariffDataLastUpdated": {
-            "$ref": "time.schema.json#/definitions/DateTimeWithOffset"
+            "description": "Timestamp that defines when the tariff data in /tariffs was last updated. Date-time in ISO 8601 / RFC 3339 style with required numeric offset in the form ±HH:MM.",
+            "allOf": [
+              { "$ref": "time.schema.json#/definitions/DateTimeWithOffset" }
+            ]
           },
           "operator": {
             "type": "string",

--- a/specification/price.schema.json
+++ b/specification/price.schema.json
@@ -57,13 +57,13 @@
       "type": "object",
       "properties": {
         "created": {
-          "$ref": "time.schema.json#/definitions/DateTimeOffset"
+          "$ref": "time.schema.json#/definitions/DateTimeWithOffset"
         },
         "start": {
-          "$ref": "time.schema.json#/definitions/DateTimeOffset"
+          "$ref": "time.schema.json#/definitions/DateTimeWithOffset"
         },
         "end": {
-          "$ref": "time.schema.json#/definitions/DateTimeOffset"
+          "$ref": "time.schema.json#/definitions/DateTimeWithOffset"
         },
         "priceExVat": {
           "type": "number",

--- a/specification/tariff.schema.json
+++ b/specification/tariff.schema.json
@@ -17,7 +17,7 @@
           "type": "string"
         },
         "published": {
-          "$ref": "time.schema.json#/definitions/DateTimeOffset"
+          "$ref": "time.schema.json#/definitions/DateTimeWithOffset"
         },
         "validPeriod": {
           "$ref": "time.schema.json#/definitions/DateInterval"

--- a/specification/time.schema.json
+++ b/specification/time.schema.json
@@ -30,7 +30,7 @@
       "example": "2025-05-25",
       "description": "Date in ISO 8601 format."
     },
-    "DateTimeOffset": {
+    "DateTimeWithOffset": {
       "type": "string",
       "format": "date-time",
       "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",

--- a/src/ControllerGenerator/Generated/GeneratedControllerBase.cs
+++ b/src/ControllerGenerator/Generated/GeneratedControllerBase.cs
@@ -109,6 +109,11 @@ namespace GeneratedController
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string ImplementationVersion { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("tariffDataLastUpdated", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$")]
+        public System.DateTimeOffset TariffDataLastUpdated { get; set; }
+
         /// <summary>
         /// Name of the company or organization operating this server.
         /// </summary>

--- a/src/ControllerGenerator/Generated/GeneratedControllerBase.cs
+++ b/src/ControllerGenerator/Generated/GeneratedControllerBase.cs
@@ -109,6 +109,9 @@ namespace GeneratedController
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string ImplementationVersion { get; set; }
 
+        /// <summary>
+        /// Timestamp that defines when the tariff data in /tariffs was last updated. Date-time in ISO 8601 / RFC 3339 style with required numeric offset in the form ±HH:MM.
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("tariffDataLastUpdated", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$")]

--- a/src/ControllerGenerator/Generated/gridtariffapi-bundle.json
+++ b/src/ControllerGenerator/Generated/gridtariffapi-bundle.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Grid Tariff API",
     "description": "Provides grid tariffs from Swedish DSOs.",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "contact": {
       "name": "Grid Tariff API",
       "url": "https://github.com/RI-SE/Eltariff-API"
@@ -291,6 +291,9 @@
             "description": "Version of the implementation. The format is set by the operator and can differ. In this example -r4 is the revision number of the implementation and the first three numbers the API version.",
             "example": "1.2.3-r4"
           },
+          "tariffDataLastUpdated": {
+            "$ref": "#/components/schemas/DateTimeWithOffset"
+          },
           "operator": {
             "type": "string",
             "description": "Name of the company or organization operating this server.",
@@ -309,6 +312,7 @@
           "name",
           "apiVersion",
           "implementationVersion",
+          "tariffDataLastUpdated",
           "operator",
           "timeZone"
         ],
@@ -416,6 +420,13 @@
         ],
         "additionalProperties": true
       },
+      "DateTimeWithOffset": {
+        "type": "string",
+        "format": "date-time",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+        "example": "2025-05-25T01:00:00+01:00",
+        "description": "Date-time in ISO 8601 / RFC 3339 style with required numeric offset in the form ±HH:MM."
+      },
       "TimeZone": {
         "type": "string",
         "description": "Time zone as described in the IANA Time Zone Database (https://www.iana.org/time-zones) e.g., 'Europe/Stockholm'.",
@@ -427,13 +438,6 @@
         "description": "Globally unique identifier",
         "example": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
         "additionalProperties": false
-      },
-      "DateTimeWithOffset": {
-        "type": "string",
-        "format": "date-time",
-        "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
-        "example": "2025-05-25T01:00:00+01:00",
-        "description": "Date-time in ISO 8601 / RFC 3339 style with required numeric offset in the form ±HH:MM."
       },
       "Date": {
         "type": "string",

--- a/src/ControllerGenerator/Generated/gridtariffapi-bundle.json
+++ b/src/ControllerGenerator/Generated/gridtariffapi-bundle.json
@@ -292,7 +292,12 @@
             "example": "1.2.3-r4"
           },
           "tariffDataLastUpdated": {
-            "$ref": "#/components/schemas/DateTimeWithOffset"
+            "description": "Timestamp that defines when the tariff data in /tariffs was last updated. Date-time in ISO 8601 / RFC 3339 style with required numeric offset in the form ±HH:MM.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTimeWithOffset"
+              }
+            ]
           },
           "operator": {
             "type": "string",

--- a/src/ControllerGenerator/Generated/gridtariffapi-bundle.json
+++ b/src/ControllerGenerator/Generated/gridtariffapi-bundle.json
@@ -216,7 +216,7 @@
           "in": "query",
           "required": false,
           "schema": {
-            "$ref": "#/components/schemas/DateTimeOffset"
+            "$ref": "#/components/schemas/DateTimeWithOffset"
           }
         },
         {
@@ -225,7 +225,7 @@
           "in": "query",
           "required": false,
           "schema": {
-            "$ref": "#/components/schemas/DateTimeOffset"
+            "$ref": "#/components/schemas/DateTimeWithOffset"
           }
         }
       ],
@@ -428,7 +428,7 @@
         "example": "216783ff-5dda-4c38-b491-d6f0fcee9a9b",
         "additionalProperties": false
       },
-      "DateTimeOffset": {
+      "DateTimeWithOffset": {
         "type": "string",
         "format": "date-time",
         "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
@@ -924,7 +924,7 @@
             "type": "string"
           },
           "published": {
-            "$ref": "#/components/schemas/DateTimeOffset"
+            "$ref": "#/components/schemas/DateTimeWithOffset"
           },
           "validPeriod": {
             "$ref": "#/components/schemas/DateInterval"
@@ -1040,13 +1040,13 @@
         "type": "object",
         "properties": {
           "created": {
-            "$ref": "#/components/schemas/DateTimeOffset"
+            "$ref": "#/components/schemas/DateTimeWithOffset"
           },
           "start": {
-            "$ref": "#/components/schemas/DateTimeOffset"
+            "$ref": "#/components/schemas/DateTimeWithOffset"
           },
           "end": {
-            "$ref": "#/components/schemas/DateTimeOffset"
+            "$ref": "#/components/schemas/DateTimeWithOffset"
           },
           "priceExVat": {
             "type": "number",

--- a/src/ExampleController/GridTariffController.cs
+++ b/src/ExampleController/GridTariffController.cs
@@ -13,11 +13,10 @@ public class GridTariffController(IWebHostEnvironment hostEnvironment) : Generat
 
     public override async Task<ActionResult<InfoResponse>> GetInfo()
     {
-        string filePath = Path.Combine(_hostEnvironment.WebRootPath, "swagger/specification", "gridtariffapi-wip.json");
+        string filePath = Path.Combine(_hostEnvironment.WebRootPath, "swagger/specification", "gridtariffapi-bundle.json");
         JsonNode json = JsonDataLoader.LoadApiSpecification(filePath);
         string? apiName = json["info"]?["title"]?.ToString();
         string? apiVersion = json["info"]?["version"]?.ToString();
-        string implementationRevision = "0.5.3";
 
         var additionalProperties = new Dictionary<string, object>
         {
@@ -29,7 +28,8 @@ public class GridTariffController(IWebHostEnvironment hostEnvironment) : Generat
         {
             Name = apiName,
             ApiVersion = apiVersion,
-            ImplementationVersion = implementationRevision,
+            ImplementationVersion = "1.2.3",
+            TariffDataLastUpdated = DateTimeOffset.Parse("2026-04-16T09:30:00+01:00"),
             Operator = "The Grid Company AB",
             TimeZone = "Europe/Stockholm",
             IdentityProviderUrl = "https://idp.gridcompany.se/oath2/token",
@@ -55,12 +55,12 @@ public class GridTariffController(IWebHostEnvironment hostEnvironment) : Generat
             }
             else if (!product.Equals("ProductCode3"))
             {
-                return NotFound($"Found no price list with id {componentId}");
+                return NotFound($"Found no price list related to product {product}");
             }
         }
         else if (!componentId.Equals(Guid.Parse("e33307b6-77b2-4d7d-b33f-908d2cc9ebbb")))
         {
-            return NotFound($"Found no price list with id {componentId}");
+            return NotFound($"Found no price list related to componentId {componentId}");
         }
 
         DateTime now = DateTime.Now;


### PR DESCRIPTION
- Rename DateTimeOffset to DateTimeWithOffset to clarify the content of the data object
- Add tariffDataLastUpdated to InfoResponse that is delivered from the /info endpoint

Fixes #65 