### PR TITLE
Add unit to PricesResponse object

### DIFF
--- a/specification/common.schema.json
+++ b/specification/common.schema.json
@@ -44,12 +44,6 @@
         "meteringPointIds"
       ],
       "additionalProperties": false
-    },
-    "Unit": {
-      "description": "The unit of a measurement or price calculation.",
-      "type": "string",
-      "example": "kWh",
-      "additionalProperties": false
     }
   }
 }

--- a/specification/energy.schema.json
+++ b/specification/energy.schema.json
@@ -33,7 +33,10 @@
           "$ref": "price.schema.json#/definitions/Price"
         },
         "unit": {
-          "$ref": "common.schema.json#/definitions/Unit"
+          "description": "Unit of energy measurement for the price rate (e.g., kWh).",
+          "type": "string",
+          "example": "kWh",
+          "additionalProperties": false
         },
         "spotPriceSettings": {
           "$ref": "energy.schema.json#/definitions/SpotPriceSettings"

--- a/specification/power.schema.json
+++ b/specification/power.schema.json
@@ -33,7 +33,10 @@
           "$ref": "price.schema.json#/definitions/Price"
         },
         "unit": {
-          "$ref": "common.schema.json#/definitions/Unit"
+          "description": "Unit for the power price rate (e.g., kW, kWh). Can represent average power over a fixed interval (e.g., 4 kW over 15 min) or equivalent energy consumption within that interval (e.g., 1 kWh per 15 min).",
+          "type": "string",
+          "example": "kW",
+          "additionalProperties": false
         },
         "url": {
           "type": "string",
@@ -56,8 +59,7 @@
         "name",
         "type",
         "reference",
-        "validPeriod",
-        "unit"
+        "validPeriod"
       ],
       "additionalProperties": false
     },

--- a/specification/price.schema.json
+++ b/specification/price.schema.json
@@ -33,6 +33,12 @@
         "currency": {
           "$ref": "price.schema.json#/definitions/Currency"
         },
+        "unit": {
+          "description": "Unit for the price rate (e.g., kW, kWh) for each entry in the actual and preview price lists. Can represent average power over a fixed interval (e.g., 4 kW over 15 min) or equivalent energy consumption within that interval (e.g., 1 kWh per 15 min).",
+          "type": "string",
+          "example": "kW",
+          "additionalProperties": false
+        },
         "actual": {
           "type": "array",
           "items": {
@@ -48,6 +54,7 @@
       },
       "required": [
         "currency",
+        "unit",
         "actual"
       ],
       "additionalProperties": true

--- a/src/ControllerGenerator/Generated/GeneratedControllerBase.cs
+++ b/src/ControllerGenerator/Generated/GeneratedControllerBase.cs
@@ -457,6 +457,9 @@ namespace GeneratedController
         [Newtonsoft.Json.JsonProperty("price", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Price Price { get; set; }
 
+        /// <summary>
+        /// Unit of energy measurement for the price rate (e.g., kWh).
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("unit", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string Unit { get; set; }
@@ -558,8 +561,10 @@ namespace GeneratedController
         [Newtonsoft.Json.JsonProperty("price", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Price Price { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("unit", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        /// <summary>
+        /// Unit for the power price rate (e.g., kW, kWh). Can represent average power over a fixed interval (e.g., 4 kW over 15 min) or equivalent energy consumption within that interval (e.g., 1 kWh per 15 min).
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("unit", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Unit { get; set; }
 
         /// <summary>
@@ -758,6 +763,13 @@ namespace GeneratedController
         [Newtonsoft.Json.JsonProperty("currency", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string Currency { get; set; }
+
+        /// <summary>
+        /// Unit for the price rate (e.g., kW, kWh) for each entry in the actual and preview price lists. Can represent average power over a fixed interval (e.g., 4 kW over 15 min) or equivalent energy consumption within that interval (e.g., 1 kWh per 15 min).
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("unit", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Unit { get; set; }
 
         [Newtonsoft.Json.JsonProperty("actual", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]

--- a/src/ControllerGenerator/Generated/gridtariffapi-bundle.json
+++ b/src/ControllerGenerator/Generated/gridtariffapi-bundle.json
@@ -429,7 +429,7 @@
         "type": "string",
         "format": "date-time",
         "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
-        "example": "2025-05-25T01:00:00+01:00",
+        "example": "2025-05-25T01:00:00+02:00",
         "description": "Date-time in ISO 8601 / RFC 3339 style with required numeric offset in the form ±HH:MM."
       },
       "TimeZone": {
@@ -602,12 +602,6 @@
         ],
         "additionalProperties": false
       },
-      "Unit": {
-        "description": "The unit of a measurement or price calculation.",
-        "type": "string",
-        "example": "kWh",
-        "additionalProperties": false
-      },
       "SpotPriceSettings": {
         "description": "Settings for a spot price relative pricing component.",
         "type": "object",
@@ -739,7 +733,10 @@
             "$ref": "#/components/schemas/Price"
           },
           "unit": {
-            "$ref": "#/components/schemas/Unit"
+            "description": "Unit of energy measurement for the price rate (e.g., kWh).",
+            "type": "string",
+            "example": "kWh",
+            "additionalProperties": false
           },
           "spotPriceSettings": {
             "$ref": "#/components/schemas/SpotPriceSettings"
@@ -858,7 +855,10 @@
             "$ref": "#/components/schemas/Price"
           },
           "unit": {
-            "$ref": "#/components/schemas/Unit"
+            "description": "Unit for the power price rate (e.g., kW, kWh). Can represent average power over a fixed interval (e.g., 4 kW over 15 min) or equivalent energy consumption within that interval (e.g., 1 kWh per 15 min).",
+            "type": "string",
+            "example": "kW",
+            "additionalProperties": false
           },
           "url": {
             "type": "string",
@@ -881,8 +881,7 @@
           "name",
           "type",
           "reference",
-          "validPeriod",
-          "unit"
+          "validPeriod"
         ],
         "additionalProperties": false
       },
@@ -1083,6 +1082,12 @@
           "currency": {
             "$ref": "#/components/schemas/Currency"
           },
+          "unit": {
+            "description": "Unit for the price rate (e.g., kW, kWh) for each entry in the actual and preview price lists. Can represent average power over a fixed interval (e.g., 4 kW over 15 min) or equivalent energy consumption within that interval (e.g., 1 kWh per 15 min).",
+            "type": "string",
+            "example": "kW",
+            "additionalProperties": false
+          },
           "actual": {
             "type": "array",
             "items": {
@@ -1098,6 +1103,7 @@
         },
         "required": [
           "currency",
+          "unit",
           "actual"
         ],
         "additionalProperties": true

--- a/src/ExampleController/Data/tariffs.json
+++ b/src/ExampleController/Data/tariffs.json
@@ -374,7 +374,6 @@
                         "description": "Dynamically set power prices for each individual hour.",
                         "type": "dynamic",
                         "reference": "main",
-                        "unit": "kW",
                         "validPeriod": {
                             "fromIncluding": "2025-01-01",
                             "toExcluding": "2026-01-01"

--- a/src/ExampleController/GridTariffController.cs
+++ b/src/ExampleController/GridTariffController.cs
@@ -104,6 +104,7 @@ public class GridTariffController(IWebHostEnvironment hostEnvironment) : Generat
         PricesResponse response = new()
         {
             Currency = "SEK",
+            Unit = "kW",
             Actual = actual,
             Preview = preview
         };


### PR DESCRIPTION
- Add better description for each place where a unit is present
- Remove unit as a required property in the PowerPriceComponent
- Add unit to the PricesResponse object with the hourly price lists

Fixes #69